### PR TITLE
fixed issue #1 now it works same as  console.log 👓 🕶👓 🕶

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,36 +1,36 @@
- function log (type = '', ...msg) {
-   const timestamp = new Date().toTimeString().split(' ')[0]
-   const isDebug = config.debug
-   let icon = ''
-   switch (type) {
-     case 'info':
-       icon = '📄'
-       break
-     case 'error':
-       icon = '💥'
-       break
-     case 'warn':
-       icon = '⚠️'
-       break
-     case 'debug':
-       icon = '🐛'
-       break
-     default:
-   }
-
-   if (['error', 'info', 'warn', 'debug'].indexOf(type) === -1) {
-     msg.unshift(type)
-   }
-   if (type.toLowerCase() !== 'debug' || isDebug) {
-     console.log(`[${timestamp}] ${icon}\t${msg.join(' ')}`)
-   }
+function log (type = '', ...msg) {
+ const timestamp = new Date().toTimeString().split(' ')[0]
+ const isDebug = config.debug
+ let icon = ''
+ switch (type) {
+   case 'info':
+     icon = '📄'
+     break
+   case 'error':
+     icon = '💥'
+     break
+   case 'warn':
+     icon = '⚠️'
+     break
+   case 'debug':
+     icon = '🐛'
+     break
+   default:
  }
 
- // register types
- ['error', 'info', 'warn', 'debug'].forEach(type => {
-   log[type] = (...msg) => log(type, ...msg)
- })
-
- module.exports = {
-   log
+ if (['error', 'info', 'warn', 'debug'].indexOf(type) === -1) {
+   msg.unshift(type)
  }
+ if (type.toLowerCase() !== 'debug' || isDebug) {
+   console.log(`[${timestamp}] ${icon}\t${msg.join(' ')}`)
+ }
+}
+
+// register types
+['error', 'info', 'warn', 'debug'].forEach(type => {
+ log[type] = (...msg) => log(type, ...msg)
+})
+
+module.exports = {
+ log
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,5 @@
 function log (msg, type = '') {
+function log (type = '', ...msg) {
   const timestamp = new Date().toTimeString().split(' ')[0]
   const isDebug = config.debug
   let icon = ''
@@ -17,14 +18,18 @@ function log (msg, type = '') {
       break
     default:
   }
+
+  if (['error', 'info', 'warn', 'debug'].indexOf(type) === -1) {
+    msg.unshift(type)
+  }
   if (type.toLowerCase() !== 'debug' || isDebug) {
-    console.log(`[${timestamp}] ${icon}\t${msg}`)
+    console.log(`[${timestamp}] ${icon}\t${msg.join(' ')}`)
   }
 }
 
 // register types
 ['error', 'info', 'warn', 'debug'].forEach(type => {
-  log[type] = msg => log(msg, type)
+  log[type] = (...msg) => log(type, ...msg)
 })
 
 module.exports = {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,37 +1,36 @@
-function log (msg, type = '') {
-function log (type = '', ...msg) {
-  const timestamp = new Date().toTimeString().split(' ')[0]
-  const isDebug = config.debug
-  let icon = ''
-  switch (type) {
-    case 'info':
-      icon = '📄'
-      break
-    case 'error':
-      icon = '💥'
-      break
-    case 'warn':
-      icon = '⚠️'
-      break
-    case 'debug':
-      icon = '🐛'
-      break
-    default:
-  }
+ function log (type = '', ...msg) {
+   const timestamp = new Date().toTimeString().split(' ')[0]
+   const isDebug = config.debug
+   let icon = ''
+   switch (type) {
+     case 'info':
+       icon = '📄'
+       break
+     case 'error':
+       icon = '💥'
+       break
+     case 'warn':
+       icon = '⚠️'
+       break
+     case 'debug':
+       icon = '🐛'
+       break
+     default:
+   }
 
-  if (['error', 'info', 'warn', 'debug'].indexOf(type) === -1) {
-    msg.unshift(type)
-  }
-  if (type.toLowerCase() !== 'debug' || isDebug) {
-    console.log(`[${timestamp}] ${icon}\t${msg.join(' ')}`)
-  }
-}
+   if (['error', 'info', 'warn', 'debug'].indexOf(type) === -1) {
+     msg.unshift(type)
+   }
+   if (type.toLowerCase() !== 'debug' || isDebug) {
+     console.log(`[${timestamp}] ${icon}\t${msg.join(' ')}`)
+   }
+ }
 
-// register types
-['error', 'info', 'warn', 'debug'].forEach(type => {
-  log[type] = (...msg) => log(type, ...msg)
-})
+ // register types
+ ['error', 'info', 'warn', 'debug'].forEach(type => {
+   log[type] = (...msg) => log(type, ...msg)
+ })
 
-module.exports = {
-  log
-}
+ module.exports = {
+   log
+ }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,36 +1,36 @@
 function log (type = '', ...msg) {
- const timestamp = new Date().toTimeString().split(' ')[0]
- const isDebug = config.debug
- let icon = ''
- switch (type) {
-   case 'info':
-     icon = '📄'
-     break
-   case 'error':
-     icon = '💥'
-     break
-   case 'warn':
-     icon = '⚠️'
-     break
-   case 'debug':
-     icon = '🐛'
-     break
-   default:
- }
+  const timestamp = new Date().toTimeString().split(' ')[0]
+  const isDebug = config.debug
+  let icon = ''
+  switch (type) {
+    case 'info':
+      icon = '📄'
+      break
+    case 'error':
+      icon = '💥'
+      break
+    case 'warn':
+      icon = '⚠️'
+      break
+    case 'debug':
+      icon = '🐛'
+      break
+    default:
+  }
 
- if (['error', 'info', 'warn', 'debug'].indexOf(type) === -1) {
-   msg.unshift(type)
- }
- if (type.toLowerCase() !== 'debug' || isDebug) {
-   console.log(`[${timestamp}] ${icon}\t${msg.join(' ')}`)
- }
+  if (['error', 'info', 'warn', 'debug'].indexOf(type) === -1) {
+    msg.unshift(type)
+  }
+  if (type.toLowerCase() !== 'debug' || isDebug) {
+    console.log(`[${timestamp}] ${icon}\t${msg.join(' ')}`)
+  }
 }
 
 // register types
 ['error', 'info', 'warn', 'debug'].forEach(type => {
- log[type] = (...msg) => log(type, ...msg)
+  log[type] = (...msg) => log(type, ...msg)
 })
 
 module.exports = {
- log
+  log
 }


### PR DESCRIPTION
- [x] fixed log function to take multiple arguments as a message string and separate them with a blank space , same as console.log function ,this is #1 issue
